### PR TITLE
Fix some dead links

### DIFF
--- a/syncmap/overlay.js
+++ b/syncmap/overlay.js
@@ -336,7 +336,7 @@ function selectStation(stationInfo) {
   $('#si-name').text(stationInfo.name);
   const region = stationInfo.region;
   const euc = encodeURIComponent;
-  const syncUrl = new URL(`/synctable/feeder.html?${euc(region)}&${euc(stationInfo.name)}`, 'https://map.adsb.lol/').toString();
+  const syncUrl = new URL(`/synctable/feeder.html?${euc(region)}&${euc(stationInfo.name)}`, 'https://mlat.adsb.lol/').toString();
   let regionInfo = region ? allRegionInfos.find(ri => ri.region === region) : null;
   if (regionInfo) {
     $('#si-region').text(`${regionInfo.name} (${region})`);

--- a/synctable/index.html
+++ b/synctable/index.html
@@ -24,7 +24,7 @@
 	<h1>MLAT sync stats for <a href="https://adsb.lol/">adsb.lol</a></h1>
 	<div class="map">
 		<h2> Also check out: <br>
-			<a target=_blank href="https://map.adsb.lol/">Interactive MLAT sync map<br>
+			<a target=_blank href="https://mlat.adsb.lol/">Interactive MLAT sync map<br>
 				<img src="img/mlat-map-thumb.png"></a>
 		</h2>
 	</div>


### PR DESCRIPTION
(I would have opened an issue before submitting this PR, but unfortunately I couldn't find where to submit one for this repo)

I've found some dead links while navigating around the site, specifically in two places.

First on the [feeder map](https://mlat.adsb.lol/syncmap/) if you select a feeder and click the "Sync Stats" link, it directs you to `https://map.adsb.lol/synctable/feeder.html` Which is a dead page.

Second if you find your way to https://mlat.adsb.lol/synctable/, it says to check out the "Interactive Sync Map" which takes you to `https://map.adsb.lol/` Which is also a dead page


It appears if you replace `map` with `mlat`, the problem is resolved, for example https://mlat.adsb.lol/synctable/feeder.html?0A&965, and https://mlat.adsb.lol/


Let me know if theres anything you need from me, or if I misunderstood the infrastructure and where links should be pointing. Thanks!